### PR TITLE
Refactor analyzeMessage with topic director

### DIFF
--- a/server.js
+++ b/server.js
@@ -1032,72 +1032,61 @@ class AriaPersonality {
 
   // PHASE 2.2: Comprehensive message analysis with MBTI fusion
   analyzeMessage(message, userHistory = [], currentIntimacyLevel = 0, conversationCount = 0, previousMBTIData = {}) {
-    const mood = this.detectMood(message);
-    const topics = this.extractTopics(message);
-    const currentTopic = topics[0] || 'general';
-
-    // Determine how long we've been on the same topic
-    let topicDepth = 1;
-    for (let i = userHistory.length - 1; i >= 0; i--) {
-      const hist = userHistory[i];
-      const histTopic = hist?.session_summary
-        ? (hist.session_summary.match(/Level \d+:([^\(]+)/) || [])[1]?.split(',')[0]?.trim()
-        : null;
-      if (histTopic && histTopic === currentTopic) {
-        topicDepth += 1;
-      } else {
-        break;
-      }
-    }
-
-    const switchKeywords = ['change subject', 'another topic', 'something else', 'new topic', 'different topic', 'skip'];
-    const shouldSwitchTopic = topicDepth >= 3 || switchKeywords.some(k => message.toLowerCase().includes(k));
-
-    const mbtiNeeds = this.assessMBTINeeds(previousMBTIData);
-    const nextQuestion = this.conversationFlow.getNextQuestion(
-      currentIntimacyLevel,
-      mood,
-      userHistory,
-      mbtiNeeds
-    );
-
-    const analysis = {
-      mood,
+    // Get base analysis using existing detectors
+    const baseAnalysis = {
+      mood: this.detectMood(message),
       energy: this.detectEnergy(message),
       interests: this.extractInterests(message),
       communication_style: this.detectCommunicationStyle(message),
       emotional_needs: this.detectEmotionalNeeds(message),
-      topics,
-      current_topic: currentTopic,
-      topic_depth: topicDepth,
-      should_switch_topic: shouldSwitchTopic,
-
-      // Enhanced psychology detection
+      topics: this.extractTopics(message),
       love_language_hints: this.detectAdvancedLoveLanguage(message),
       attachment_hints: this.detectAdvancedAttachment(message),
       family_values_hints: this.detectFamilyValueHints(message),
-
-      // PHASE 2.2: Enhanced MBTI with emotional fusion
       mbti_analysis: this.analyzeMBTIWithEmotionalFusion(message, userHistory),
-
-      // Conversation flow analysis
       intimacy_signals: this.detectIntimacySignals(message),
       story_sharing_level: this.assessStorySharing(message),
       emotional_openness: this.assessEmotionalOpenness(message),
-
-      // PHASE 2.2: Strategic conversation management
-      mbti_needs: mbtiNeeds,
+      mbti_needs: this.assessMBTINeeds(previousMBTIData),
       should_level_up: this.conversationFlow.shouldLevelUp(message, currentIntimacyLevel, conversationCount),
-      next_question_suggestion: nextQuestion,
-      conversation_guidance: this.getIntimacyGuidance(currentIntimacyLevel, mood) + (shouldSwitchTopic ? '\nConsider smoothly transitioning to a new subject.' : ''),
-
-      // Celebration and resistance detection
       celebration_opportunity: this.detectCelebrationMoment(message),
       resistance_signals: this.detectResistance(message),
       topic_bridges: this.generateTopicBridges(message)
     };
 
-    return analysis;
+    // Topic Director logic
+    const currentTopic = this.identifyCurrentTopic(message, userHistory);
+    const topicDepth = this.calculateTopicDepth(currentTopic, userHistory);
+    const shouldSwitch = topicDepth >= 3;
+
+    // Determine next question and guidance
+    let nextQuestion;
+    let conversationGuidance;
+
+    if (shouldSwitch) {
+      nextQuestion = this.generateTopicTransition(currentTopic, baseAnalysis);
+      conversationGuidance = 'transition_topic';
+    } else if (baseAnalysis.resistance_signals?.detected) {
+      nextQuestion = this.generateResistanceResponse(baseAnalysis);
+      conversationGuidance = 'gentle_approach';
+    } else {
+      nextQuestion = this.conversationFlow.getNextQuestion(
+        currentIntimacyLevel,
+        baseAnalysis.mood,
+        userHistory,
+        baseAnalysis.mbti_needs
+      );
+      conversationGuidance = 'continue_exploration';
+    }
+
+    return {
+      ...baseAnalysis,
+      current_topic: currentTopic,
+      topic_depth: topicDepth,
+      should_switch_topic: shouldSwitch,
+      conversation_guidance: conversationGuidance,
+      next_question_suggestion: nextQuestion
+    };
   }
 
   // PHASE 2.2: MBTI Analysis with Emotional Intelligence Fusion


### PR DESCRIPTION
## Summary
- revamp `analyzeMessage` to integrate Topic Director logic
- use existing detection helpers to build a base analysis
- generate transition prompts and guidance when topics become stale

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `node --check server.js`

------
https://chatgpt.com/codex/tasks/task_e_68472ed04fcc833292d78107a92f36b9