### PR TITLE
Add Jest test for direct interest detection

### DIFF
--- a/detectDirectInterest.js
+++ b/detectDirectInterest.js
@@ -1,0 +1,40 @@
+function detectDirectInterest(message, userHistory = []) {
+  const msg = message.toLowerCase();
+
+  const relationshipKeywords = [
+    'future', 'marriage', 'relationship', 'compatibility', 'partner',
+    'family planning', 'life together', 'settle down', 'serious relationship',
+    'long term', 'commitment', 'values', 'life goals', 'future plans',
+    'couple compass', 'compatibility quiz', 'relationship test',
+    'matchmaking service', 'compatibility questionnaire', 'ready for love',
+    'looking for someone', 'ideal partner', 'relationship values',
+    'what i want in', 'future together', 'building a life'
+  ];
+
+  const matchedKeywords = relationshipKeywords.filter(keyword => msg.includes(keyword));
+
+  const directQuestions = [
+    'what makes relationships work', 'how do you know compatibility',
+    'what do you look for', 'ideal relationship', 'relationship values',
+    'ready for something serious', 'looking for long term',
+    'what matters in love', 'relationship goals', 'perfect match'
+  ];
+
+  const directQuestionDetected = directQuestions.some(question => msg.includes(question));
+
+  const historyKeywords = userHistory.slice(-3).some(entry => {
+    if (entry.role !== 'user') return false;
+    const content = (entry.content || '').toLowerCase();
+    return relationshipKeywords.some(keyword => content.includes(keyword));
+  });
+
+  return {
+    detected: matchedKeywords.length > 0 || directQuestionDetected || historyKeywords,
+    keywords: matchedKeywords,
+    directQuestion: directQuestionDetected,
+    fromHistory: historyKeywords,
+    strength: matchedKeywords.length > 1 ? 'strong' : 'medium'
+  };
+}
+
+module.exports = detectDirectInterest;

--- a/package.json
+++ b/package.json
@@ -4,11 +4,15 @@
   "description": "Adaptive AI backend with emotional intelligence",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.18.2",
     "cors": "^2.8.5",
     "pg": "^8.11.3"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/tests/detectDirectInterest.test.js
+++ b/tests/detectDirectInterest.test.js
@@ -1,0 +1,29 @@
+const detectDirectInterest = require('../detectDirectInterest');
+
+describe('detectDirectInterest', () => {
+  test('detects direct question about compatibility', () => {
+    const result = detectDirectInterest('How do you know when someone is compatible?');
+    expect(result.detected).toBe(true);
+    expect(result.directQuestion).toBe(true);
+  });
+
+  test('detects relationship keywords', () => {
+    const result = detectDirectInterest('I am looking for a long term relationship and life together.');
+    expect(result.detected).toBe(true);
+    expect(result.keywords.length).toBeGreaterThan(0);
+  });
+
+  test('detects interest from conversation history', () => {
+    const history = [
+      { role: 'user', content: 'I want to settle down someday.' }
+    ];
+    const result = detectDirectInterest('Tell me more about yourself.', history);
+    expect(result.detected).toBe(true);
+    expect(result.fromHistory).toBe(true);
+  });
+
+  test('returns false for unrelated message', () => {
+    const result = detectDirectInterest('The weather is nice today.');
+    expect(result.detected).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest dev dependency and test script
- expose `detectDirectInterest` logic as a standalone module
- create unit tests for direct-interest detection

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848294032b48332a82cde4ffefaadec