### PR TITLE
Fix generateSystemPrompt to use gameState

### DIFF
--- a/server.js
+++ b/server.js
@@ -2406,7 +2406,7 @@ class AriaPersonality {
   }
 
   // Generate warm, PRD-style system prompt
-  generateSystemPrompt(userAnalysis, userProfile, conversationHistory, user, coupleCompassState = null) {
+  generateSystemPrompt(userAnalysis, userProfile, conversationHistory, user, coupleCompassState = null, gameState = null) {
     const {
       mood,
       energy,
@@ -3466,7 +3466,8 @@ app.post('/api/chat', async (req, res) => {
         updatedProfile.personalityData,
         conversationHistory,
         user,
-        gameState || coupleCompassState // Use new gameState if available
+        coupleCompassState,
+        gameState
       );
 
       // Prepare messages with natural conversation prompt


### PR DESCRIPTION
## Summary
- add `gameState` parameter to `generateSystemPrompt`
- pass `gameState` when generating system prompt in chat endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eaab07f6c8332977f94483e466b3e