### PR TITLE
Fix Couple Compass question formatting

### DIFF
--- a/server.js
+++ b/server.js
@@ -2140,7 +2140,12 @@ function getCoupleCompassQuestionText(questionIndex) {
 
   if (questionIndex >= 0 && questionIndex < questions.length) {
     const q = questions[questionIndex];
-    return `${q.text}\n\nA) ${q.options[0]}\nB) ${q.options[1]}\nC) ${q.options[2]}\nD) ${q.options[3]}`;
+    return `${q.text}
+
+A) ${q.options[0]}
+B) ${q.options[1]}
+C) ${q.options[2]}
+D) ${q.options[3]}`;
   }
 
   return null;


### PR DESCRIPTION
## Summary
- adjust Couple Compass question formatting in `getCoupleCompassQuestionText`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685139a5eb3883329187544227fe9619