### PR TITLE
Add stuck detection feature flag

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,6 +5,9 @@ const cors = require('cors');
 const { Pool } = require('pg');
 const app = express();
 
+// Feature flags
+const ENABLE_STUCK_DETECTION = false; // Disabled - was causing false positives on normal conversation
+
 // CORS configuration
 app.use(cors({
   origin: '*',
@@ -5569,7 +5572,11 @@ app.post('/api/chat', async (req, res) => {
         conversationHistory.length
       );
 
-      if (directorCheck.isStuck || directorCheck.shouldEscalate) {
+      if (!ENABLE_STUCK_DETECTION && (directorCheck.isStuck || directorCheck.shouldEscalate)) {
+        console.log('\uD83D\uDEAB Stuck detection would have triggered but is disabled');
+      }
+
+      if (ENABLE_STUCK_DETECTION && (directorCheck.isStuck || directorCheck.shouldEscalate)) {
         // Check last AI message to prevent loops
         const lastAIMessage = messages.slice().reverse().find(m => m.role === 'assistant');
         const isAlreadyEscape = lastAIMessage?.content?.includes('going in circles') ||


### PR DESCRIPTION
## Summary
- introduce `ENABLE_STUCK_DETECTION` feature flag
- log when stuck detection would trigger but is disabled
- gate stuck detection logic behind the flag

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fbf34e23883329fa03e77d5d67b53