### PR TITLE
Add debug logs for couple compass progression

### DIFF
--- a/server.js
+++ b/server.js
@@ -5472,9 +5472,16 @@ app.post('/api/chat', async (req, res) => {
       const ariaOfferedCompass = ariaLastMessage.toLowerCase().includes('couple compass') &&
                                 (ariaLastMessage.includes('would you like') ||
                                  ariaLastMessage.includes('ready to begin'));
+      const userMessage = latestUserMessage.content.toLowerCase();
+
+      console.log(`🔍 DEBUG - Acceptance detection:
+  - previousMessages count: ${previousMessages.length}
+  - ariaLastMessage preview: ${ariaLastMessage.substring(0, 50)}...
+  - ariaOfferedCompass: ${ariaOfferedCompass}
+  - userMessage: ${userMessage}
+`);
 
       if (ariaOfferedCompass && !alreadyCompleted && !coupleCompassState?.active) {
-        const userMessage = latestUserMessage.content.toLowerCase();
         const acceptanceWords = [
           'yes', 'sure', 'ok', 'okay', 'let\'s go', 'lets go', 'let\'s do',
           'lets do', 'let\'s start', 'lets start', 'yeah', 'yep', 'absolutely',
@@ -5687,6 +5694,15 @@ app.post('/api/chat', async (req, res) => {
                                          conversationHistory.length >= 5 &&
                                          !alreadyCompleted &&
                                          !skipAutoProgression;
+
+      console.log(`🔍 DEBUG - Auto-progression check for ${userName}:
+  - alreadyCompleted: ${alreadyCompleted}
+  - skipAutoProgression: ${skipAutoProgression}
+  - hasEnoughData: ${autoProgressCheck.hasEnoughData}
+  - conversationHistory.length: ${conversationHistory.length}
+  - gameState exists: ${!!gameState}
+  - coupleCompassState?.active: ${coupleCompassState?.active}
+`);
 
       // Only force invitation if truly needed
       if (autoProgressCheck.readyForCompass && !coupleCompassState?.active && !gameState) {


### PR DESCRIPTION
## Summary
- help debug repeated invitations to Couple Compass by logging conversation context
- log key metrics before inviting to the quiz

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fdc86a5348332a9846b07ef9df220