### PR TITLE
Update topic closure logic

### DIFF
--- a/server.js
+++ b/server.js
@@ -1218,10 +1218,13 @@ class TopicTracker {
         result = userData.love_language_hints?.length > 0;
         break;
       case 'values':
-        result = userData.values_discovered?.length >= 3 || userData.user_preferences?.values;
+        result = userData.values_discovered?.length >= 3 ||
+                 userData.user_preferences?.values ||
+                 userData.values_alignment !== undefined;
         console.log(`🔍 Topic 'values' closed check:
           - values_discovered: ${JSON.stringify(userData.values_discovered)}
           - user_preferences.values: ${userData.user_preferences?.values}
+          - values_alignment: ${JSON.stringify(userData.values_alignment)}
           - Is closed: ${result}
         `);
         break;


### PR DESCRIPTION
## Summary
- broaden `values` closed condition in `TopicTracker`
- log `values_alignment` when checking topic closure

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860f968339483328a3ebbac8cbd2d5e