### PR TITLE
Update report readiness criteria

### DIFF
--- a/server.js
+++ b/server.js
@@ -4579,20 +4579,28 @@ RESPONSE FRAMEWORK:
 
   // Assess if ready for report generation
   assessReportReadiness(mbtiData, conversationCount) {
-    const mbtiComplete = this.assessMBTICompleteness(mbtiData.mbti_confidence_scores || {});
+    const mbtiComplete = this.assessMBTICompleteness(
+      mbtiData.mbti_confidence_scores || {}
+    );
     const coupleCompassComplete = mbtiData.couple_compass_complete || false;
-    const result = {
-      ready: mbtiComplete.ready && coupleCompassComplete,
-      missing: !mbtiComplete.ready ? 'personality data' : !coupleCompassComplete ? 'couple compass' : null
-    };
+
+    const mbtiReady = mbtiComplete.highConfidenceDimensions >= 2;
+    const compassReady = coupleCompassComplete && conversationCount >= 10;
+
+    const ready = mbtiReady || compassReady;
+    let missing = null;
+    if (!ready) {
+      missing = !mbtiReady ? 'personality data' : 'couple compass';
+    }
 
     console.log(`📊 Report Readiness Check:
-  - MBTI Complete: ${mbtiComplete.ready} (${mbtiComplete.highConfidenceDimensions}/4 dimensions)
+  - MBTI High Dimensions: ${mbtiComplete.highConfidenceDimensions}/4
   - Couple Compass: ${coupleCompassComplete}
-  - Overall Ready: ${result.ready}
+  - Conversation Count: ${conversationCount}
+  - Overall Ready: ${ready}
 `);
 
-    return result;
+    return { ready, missing };
   }
 
   // Detect direct interest in relationships/compatibility


### PR DESCRIPTION
## Summary
- relax criteria for generating the personal report
- ready when user has at least two MBTI dimensions or completed Couple Compass after enough conversation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860fa094d0c8332992259be63ebce10