### PR TITLE
Add debug log before OpenAI call

### DIFF
--- a/server.js
+++ b/server.js
@@ -5916,6 +5916,18 @@ app.post('/api/chat', async (req, res) => {
         });
       }
 
+      // Debug: log MBTI scores and values before calling OpenAI
+      const roundedMBTI = Object.fromEntries(
+        Object.entries(updatedProfile.personalityData.mbti_confidence_scores || {})
+          .map(([dim, score]) => [dim, Math.round(score)])
+      );
+      console.log(
+        `➡️ OpenAI call for ${userName}:`,
+        `MBTI ${JSON.stringify(roundedMBTI)}`,
+        `values ${JSON.stringify(updatedProfile.personalityData.values_discovered || [])}`,
+        `reportReady ${analysis.ready_for_report?.ready}`
+      );
+
       // Call OpenAI with optimized settings
       const response = await fetch('https://api.openai.com/v1/chat/completions', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- log rounded MBTI scores, discovered values, and report status before hitting the OpenAI API

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860fa24868c8332bd37b9b4425cc7ce