### PR TITLE
Add malformed JSON middleware

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,6 +13,14 @@ app.use(cors({
   credentials: false
 }));
 app.use(express.json());
+// Error handler for malformed JSON
+app.use((err, req, res, next) => {
+  if (err instanceof SyntaxError && err.status === 400 && 'body' in err) {
+    console.error('Bad JSON:', err.message);
+    return res.status(400).json({ error: 'Invalid JSON format' });
+  }
+  next();
+});
 
 // Handle preflight requests
 app.options('*', cors());


### PR DESCRIPTION
## Summary
- add middleware in `server.js` to return a 400 for malformed JSON bodies

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868038f4fb083328ef030ec6a6452b0