### PR TITLE
Implement conversation pattern review and emotional state

### DIFF
--- a/server.js
+++ b/server.js
@@ -1612,6 +1612,17 @@ app.post('/api/chat', async (req, res) => {
           context
         );
 
+        // Periodic deep pattern review
+        const userMessageCount = messages.filter(m => m.role === 'user').length;
+        const patternInsights = await gptBrain.reviewConversationPatterns(
+          userId,
+          userMessageCount,
+          conversationHistory
+        );
+
+        // Merge pattern insights with regular insights
+        Object.assign(insights, patternInsights);
+
         await gptBrain.saveInsights(userId, insights);
         await gptBrain.saveMemory(userId, latestUserMessage.content);
 


### PR DESCRIPTION
## Summary
- detect frustration and engagement in `assessConversationState`
- record these fields in the built conversation context
- enhance system prompt with emotional state and new response rules
- add periodic pattern review via `reviewConversationPatterns`
- call pattern review from `/api/chat`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686916223c4883329fb9a568d4778739