### PR TITLE
Add missing extraction tracking column

### DIFF
--- a/server.js
+++ b/server.js
@@ -242,6 +242,11 @@ async function initializeDatabase() {
       CREATE INDEX IF NOT EXISTS idx_users_life_stage ON users(life_stage)
     `);
 
+    // Add missing column for extraction tracking
+    await pool.query(`
+      ALTER TABLE users ADD COLUMN IF NOT EXISTS last_extraction_message_count INTEGER DEFAULT 0
+    `);
+
     console.log('✅ Database tables initialized successfully');
   } catch (error) {
     console.error('❌ Database initialization error:', error);


### PR DESCRIPTION
## Summary
- ensure database initialization adds `last_extraction_message_count` column

## Testing
- `npx --yes jest` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_687df9da69ec8332acf7e10e992201a9