### PR TITLE
Fix update of extraction tracking

### DIFF
--- a/server.js
+++ b/server.js
@@ -630,7 +630,7 @@ Return ONLY valid JSON. If something isn't clear from the conversation, omit it 
       
       // Update extraction tracking
       await pool.query(
-        'UPDATE user_threads SET last_extraction = NOW(), extraction_count = extraction_count + 1 WHERE user_id = $1',
+        'UPDATE user_threads SET last_extraction = NOW() WHERE user_id = $1',
         [userId]
       );
       


### PR DESCRIPTION
## Summary
- correct the `pool.query` used to update extraction tracking

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f7588a55c83329cfeb36c415aac99